### PR TITLE
Added dependency to fastscript

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -17,7 +17,7 @@ status = 4
 nbs_path = .
 doc_path = docs
 console_scripts = fastgpu_poll=fastgpu.cli:fastgpu_poll
-requirements = fastcore>=1.0.0 pynvml
+requirements = fastcore>=1.0.0 fastscript>=1.0.0 pynvml
 conda_requirements = numpy
 git_url = https://github.com/fastai/fastgpu/tree/master/
 lib_path = fastgpu


### PR DESCRIPTION
An install of fastgpu in a clean environment will cause exception on https://github.com/fastai/fastgpu/blob/4542069dc280b00499299445d500dd59c98fa230/fastgpu/cli.py#L2
I added a dependency to fastscript>=1.0.0 in order to fix it.